### PR TITLE
adding raptor control policy

### DIFF
--- a/examples/basic_usage_raptor.py
+++ b/examples/basic_usage_raptor.py
@@ -1,0 +1,121 @@
+"""
+Imports
+"""
+# The simulator is instantiated using the Environment class
+from rotorpy.environments import Environment
+
+# Vehicles. Currently there is only one. 
+# There must also be a corresponding parameter file. 
+from rotorpy.vehicles.multirotor import Multirotor
+from rotorpy.vehicles.crazyflie_params import quad_params
+# from rotorpy.vehicles.hummingbird_params import quad_params  # There's also the Hummingbird
+
+# You will also need a controller (currently there is only one) that works for your vehicle. 
+from rotorpy.controllers.quadrotor_control import SE3Control
+from rotorpy.controllers.raptor import FoudationPolicy
+
+# And a trajectory generator
+from rotorpy.trajectories.hover_traj import HoverTraj
+from rotorpy.trajectories.circular_traj import ThreeDCircularTraj
+from rotorpy.trajectories.lissajous_traj import TwoDLissajous
+from rotorpy.trajectories.speed_traj import ConstantSpeed
+from rotorpy.trajectories.minsnap import MinSnap
+
+# You can optionally specify a wind generator, although if no wind is specified it will default to NoWind().
+from rotorpy.wind.default_winds import NoWind, ConstantWind, SinusoidWind, LadderWind
+from rotorpy.wind.dryden_winds import DrydenGust, DrydenGustLP
+from rotorpy.wind.spatial_winds import WindTunnel
+
+# You can also optionally customize the IMU and motion capture sensor models. If not specified, the default parameters will be used. 
+from rotorpy.sensors.imu import Imu
+from rotorpy.sensors.external_mocap import MotionCapture
+
+# You can also specify a state estimator. This is optional. If no state estimator is supplied it will default to null. 
+try:
+      from rotorpy.estimators.wind_ukf import WindUKF
+except:
+      print("FilterPy is not installed in the basic version of rotorpy. Please install the filter version of rotorpy by running pip install rotorpy[filter]")
+
+# Also, worlds are how we construct obstacles. The following class contains methods related to constructing these maps. 
+from rotorpy.world import World
+
+# Reference the files above for more documentation. 
+
+# Other useful imports
+import numpy as np                  # For array creation/manipulation
+import matplotlib.pyplot as plt     # For plotting, although the simulator has a built in plotter
+from scipy.spatial.transform import Rotation  # For doing conversions between different rotation descriptions, applying rotations, etc. 
+import os                           # For path generation
+
+"""
+Instantiation
+"""
+
+# Obstacle maps can be loaded in from a JSON file using the World.from_file(path) method. Here we are loading in from 
+# an existing file under the rotorpy/worlds/ directory. However, you can create your own world by following the template
+# provided (see rotorpy/worlds/README.md), and load that file anywhere using the appropriate path.
+world = World.from_file(os.path.abspath(os.path.join(os.path.dirname(__file__),'..','rotorpy','worlds','double_pillar.json')))
+
+# "world" is an optional argument. If you don't load a world it'll just provide an empty playground! 
+
+# An instance of the simulator can be generated as follows: 
+sim_instance = Environment(vehicle=Multirotor(quad_params),           # vehicle object, must be specified. 
+                        #    controller=SE3Control(quad_params),        # controller object, must be specified.
+                           controller=FoudationPolicy(quad_params),     # use RAPTOR policy
+                        #    trajectory=HoverTraj(x0=np.array([0, 0, 1])),         # trajectory object, must be specified.
+                           trajectory=ThreeDCircularTraj(center=np.array([0,0,1]), radius=np.array([1,1,0])),         # trajectory object, must be specified.
+                           wind_profile=None,               # OPTIONAL: wind profile object, if none is supplied it will choose no wind. 
+                           sim_rate     = 100,                        # OPTIONAL: The update frequency of the simulator in Hz. Default is 100 Hz.
+                           imu          = None,                       # OPTIONAL: imu sensor object, if none is supplied it will choose a default IMU sensor.
+                           mocap        = None,                       # OPTIONAL: mocap sensor object, if none is supplied it will choose a default mocap.  
+                           estimator    = None,                       # OPTIONAL: estimator object
+                           world        = None,                      # OPTIONAL: the world, same name as the file in rotorpy/worlds/, default (None) is empty world
+                           safety_margin= 0.25                        # OPTIONAL: defines the radius (in meters) of the sphere used for collision checking
+                       )
+
+# This generates an Environment object that has a unique vehicle, controller, and trajectory.  
+# You can also optionally specify a wind profile, IMU object, motion capture sensor, estimator, 
+# and the simulation rate for the simulator.  
+
+"""
+Execution
+"""
+
+# Setting an initial state. This is optional, and the state representation depends on the vehicle used. 
+# Generally, vehicle objects should have an "initial_state" attribute. 
+x0 = {'x': np.array([0,0,1]),
+      'v': np.array([0, 0, 0]),
+      'q': np.array([0, 0, 0, 1]), # [i,j,k,w]
+      'w': np.zeros(3,),
+      'wind': np.array([0,0,0]),  # Since wind is handled elsewhere, this value is overwritten
+      'rotor_speeds': np.array([1788.53, 1788.53, 1788.53, 1788.53])}
+sim_instance.vehicle.initial_state = x0
+
+# Executing the simulator as specified above is easy using the "run" method: 
+# All the arguments are listed below with their descriptions. 
+# You can save the animation (if animating) using the fname argument. Default is None which won't save it.
+
+results = sim_instance.run(t_final      = 20,       # The maximum duration of the environment in seconds
+                           use_mocap    = True,       # Boolean: determines if the controller should use the motion capture estimates. 
+                           terminate    = False,       # Boolean: if this is true, the simulator will terminate when it reaches the last waypoint.
+                           plot            = True,     # Boolean: plots the vehicle states and commands   
+                           plot_mocap      = False,     # Boolean: plots the motion capture pose and twist measurements
+                           plot_estimator  = False,     # Boolean: plots the estimator filter states and covariance diagonal elements
+                           plot_imu        = False,     # Boolean: plots the IMU measurements
+                           animate_bool    = True,     # Boolean: determines if the animation of vehicle state will play. 
+                           animate_wind    = False,    # Boolean: determines if the animation will include a scaled wind vector to indicate the local wind acting on the UAV. 
+                           verbose         = True,     # Boolean: will print statistics regarding the simulation. 
+                           fname   = None # Filename is specified if you want to save the animation. The save location is rotorpy/data_out/. 
+                    )
+
+# There are booleans for if you want to plot all/some of the results, animate the multirotor, and 
+# if you want the simulator to output the EXIT status (end time reached, out of control, etc.)
+# The results are a dictionary containing the relevant state, input, and measurements vs time.
+
+# To save this data as a .csv file, you can use the environment's built in save method. You must provide a filename. 
+# The save location is rotorpy/data_out/
+sim_instance.save_to_csv("basic_usage.csv")
+
+# Instead of producing a CSV, you can manually unpack the dictionary into a Pandas DataFrame using the following: 
+from rotorpy.utils.postprocessing import unpack_sim_data
+dataframe = unpack_sim_data(results)

--- a/examples/basic_usage_raptor.py
+++ b/examples/basic_usage_raptor.py
@@ -8,11 +8,10 @@ from rotorpy.environments import Environment
 # There must also be a corresponding parameter file. 
 from rotorpy.vehicles.multirotor import Multirotor
 from rotorpy.vehicles.crazyflie_params import quad_params
-# from rotorpy.vehicles.hummingbird_params import quad_params  # There's also the Hummingbird
 
 # You will also need a controller (currently there is only one) that works for your vehicle. 
 from rotorpy.controllers.quadrotor_control import SE3Control
-from rotorpy.controllers.raptor import FoudationPolicy
+from rotorpy.controllers.raptor import RaptorFoundationPolicy
 
 # And a trajectory generator
 from rotorpy.trajectories.hover_traj import HoverTraj
@@ -60,9 +59,7 @@ world = World.from_file(os.path.abspath(os.path.join(os.path.dirname(__file__),'
 
 # An instance of the simulator can be generated as follows: 
 sim_instance = Environment(vehicle=Multirotor(quad_params),           # vehicle object, must be specified. 
-                        #    controller=SE3Control(quad_params),        # controller object, must be specified.
-                           controller=FoudationPolicy(quad_params),     # use RAPTOR policy
-                        #    trajectory=HoverTraj(x0=np.array([0, 0, 1])),         # trajectory object, must be specified.
+                           controller=RaptorFoundationPolicy(quad_params),     # use RAPTOR policy
                            trajectory=ThreeDCircularTraj(center=np.array([0,0,1]), radius=np.array([1,1,0])),         # trajectory object, must be specified.
                            wind_profile=None,               # OPTIONAL: wind profile object, if none is supplied it will choose no wind. 
                            sim_rate     = 100,                        # OPTIONAL: The update frequency of the simulator in Hz. Default is 100 Hz.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rotorpy"
-version = "2.0.2"
+version = "2.0.3"
 description = "A multirotor simulator with aerodynamics for education and research."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -49,9 +49,15 @@ testing = [
     'pytest',
     'filterpy == 1.4.5',
     'stable_baselines3',
+    'foundation-policy==1.0.1',
 ]
 filter = [
     'filterpy == 1.4.5',
+]
+raptor = [
+    'stable_baselines3',
+    'tensorboard',
+    'foundation-policy==1.0.1',
 ]
 
 [project.urls]

--- a/rotorpy/controllers/raptor.py
+++ b/rotorpy/controllers/raptor.py
@@ -1,0 +1,93 @@
+from foundation_policy import Raptor
+from scipy.spatial.transform import Rotation
+import numpy as np
+
+class FoudationPolicy(object):
+    """
+    implementing the RAPTOP policy
+    """
+    def __init__(self, quad_params):
+        """
+        Parameters:
+            quad_params, dict with keys specified in rotorpy/vehicles
+        """
+
+        self.policy = Raptor()
+        self.policy.reset()
+
+        # initialize the action
+        self.action_past = np.zeros(4)
+
+        # load rpm info
+        self.rotor_speed_min = quad_params['rotor_speed_min']
+        self.rotor_speed_max = quad_params['rotor_speed_max']
+
+    def update(self, t, state, flat_output):
+        """
+        This function receives the current time, true state, and desired flat
+        outputs. It returns the command inputs.
+
+        Inputs:
+            t, present time in seconds
+            state, a dict describing the present state with keys
+                x, position, m
+                v, linear velocity, m/s
+                q, quaternion [i,j,k,w]
+                w, angular velocity, rad/s
+            flat_output, a dict describing the present desired flat outputs with keys
+                x,        position, m
+                x_dot,    velocity, m/s
+                x_ddot,   acceleration, m/s**2
+                x_dddot,  jerk, m/s**3
+                x_ddddot, snap, m/s**4
+                yaw,      yaw angle, rad
+                yaw_dot,  yaw rate, rad/s
+
+        Outputs:
+            control_input, a dict describing the present computed control inputs with keys
+                cmd_motor_speeds, rad/s
+                cmd_motor_thrusts, N
+                cmd_thrust, N 
+                cmd_moment, N*m
+                cmd_q, quaternion [i,j,k,w]
+                cmd_w, angular rates in the body frame, rad/s
+                cmd_v, velocity in the world frame, m/s
+        """
+
+        # fetch the state estimates (the policy works under ENU frame)
+        pos = state['x']
+        vel = state['v']
+        R = Rotation.from_quat(state['q']).as_matrix()
+        omega = state['w']
+
+        # fetch target pos and vel
+        target_pos = flat_output['x']
+        target_vel = flat_output['x_dot']
+        
+        # for trajectory, use pos-target_pos and vel-target_vel
+        observation = np.hstack((pos - target_pos, R.flatten(), vel-target_vel, omega, self.action_past))
+
+        # clip policy outputs to be the defined range [-1, 1]
+        action = np.clip(self.policy.evaluate_step(observation)[0], -1, 1)
+        # save current control action
+        self.action_past = action
+
+        # put dummy cmd_moment and cmd_q just to pass the sanity check
+        # control-wise, the cmd_motor_speeds has priority
+        cmd_moment_dummy = np.zeros((3,))
+        cmd_q_dummy = np.array([0,0,0,1])
+        cmd_thrust_dummy = 0
+        
+        # remap the motor numbers
+        action_remapped = np.array([action[3], action[0], action[1], action[2]])
+        
+        # denormalize based on https://github.com/rl-tools/raptor?tab=readme-ov-file#usage
+        action_rpm = (self.rotor_speed_max - self.rotor_speed_min) * (action_remapped + 1)/2 + self.rotor_speed_min
+        
+        # load control
+        control_input = {'cmd_motor_speeds':action_rpm,
+                         'cmd_thrust':cmd_thrust_dummy,
+                         'cmd_moment':cmd_moment_dummy,
+                         'cmd_q':cmd_q_dummy}
+        
+        return control_input

--- a/rotorpy/controllers/raptor.py
+++ b/rotorpy/controllers/raptor.py
@@ -2,7 +2,7 @@ from foundation_policy import Raptor
 from scipy.spatial.transform import Rotation
 import numpy as np
 
-class FoudationPolicy(object):
+class RaptorFoundationPolicy(object):
     """
     implementing the RAPTOP policy
     """


### PR DESCRIPTION
We implemented the raptor control policy from a recent paper titled ["RAPTOR: A Foundation Policy for Quadrotor
Control"](https://www.arxiv.org/pdf/2509.11481). 

Simply install raptor with
`pip install foundation-policy==1.0.1`
and run the example code:
`python3 /examples/basic_usage_raptor.py`