### PR TITLE
More realistic tau_m for the Crazyflie

### DIFF
--- a/rotorpy/vehicles/crazyflie_params.py
+++ b/rotorpy/vehicles/crazyflie_params.py
@@ -52,7 +52,7 @@ quad_params = {
     'k_flap': 0.0,              # Flapping moment coefficient Nm/(rad*m/s**2) = kg*m/rad
 
     # Motor properties
-    'tau_m': 0.005,           # motor response time, seconds
+    'tau_m': 0.072,           # motor response time, seconds
     'rotor_speed_min': 0,       # rad/s
     'rotor_speed_max': 2500,    # rad/s
     'motor_noise_std': 0.0,     # rad/s


### PR DESCRIPTION
Hi,

when experimenting with RAPTOR in RotorPy I noticed some weird behavior that looks like integrator overshooting. This looks plausible because `tau_m=0.005` (for the Crazyflie), while the simulation frequency seems to be 100 Hz in most examples. I think the best fix is to give the Crazyflie a more realistic `tau_m=0.072`. The value is based on our results in [Data-Driven System Identification of Quadrotors Subject to Motor Delays](https://arxiv.org/abs/2404.07837) and also plausible when checking [Bitcraze's plots](https://web.archive.org/web/20220309092320/https://www.bitcraze.io/wp-content/uploads/2015/02/M1-step-response.png).

Best regards!
Jonas