### PR TITLE
Increase body rate P gain for crazyflie controller

### DIFF
--- a/rotorpy/vehicles/crazyflie_params.py
+++ b/rotorpy/vehicles/crazyflie_params.py
@@ -59,7 +59,7 @@ quad_params = {
     'motor_noise_std': 0.0,     # rad/s
 
     # Lower level controller properties (for higher level control abstractions)
-    'k_w': 1,               # The body rate P gain (for cmd_ctbr)
+    'k_w': 200,               # The body rate P gain (for cmd_ctbr)
     'k_v': 10,              # The *world* velocity P gain (for cmd_vel)
     'kp_att': 1030,      # The attitude P gain (for cmd_vel, cmd_acc, and cmd_ctatt)
     'kd_att': 51,       # The attitude D gain (for cmd_vel, cmd_acc, and cmd_ctatt)


### PR DESCRIPTION
Increase body rate P gain for controller to the standard in the crazyflie firmware. Fixes oscillations in cmd_ctbr control abstraction mode. Fixes #39 