### PR TITLE
Increase speed threshold for safety exit check

### DIFF
--- a/rotorpy/simulate.py
+++ b/rotorpy/simulate.py
@@ -213,7 +213,7 @@ def safety_exit(world, margin, state, flat, control):
     """
     Return exit status if any safety condition is violated, otherwise None.
     """
-    if np.any(np.abs(state['v']) > 20):
+    if np.any(np.abs(state['v']) > 100):
         return ExitStatus.OVER_SPEED
     if np.any(np.abs(state['w']) > 100):
         return ExitStatus.OVER_SPIN


### PR DESCRIPTION
Increase speed threshold for safety exit check to the speed given in the error message.
Currently the error message claims that a speed of more than 100m/s was achieved yet the error is already triggered at 20m/s.